### PR TITLE
Add Public Mentee Profile Views + Made Public Profile Views Accessible From Match Pages

### DIFF
--- a/Backend/Routes/users.js
+++ b/Backend/Routes/users.js
@@ -284,6 +284,29 @@ router.get("/mentors/:id", async (req, res) => {
   }
 });
 
+// Route to fetch mentor profile based on mentorId, not userId
+router.get("/mentors/mentorId/:id", async (req, res) => {
+  const mentorId = req.params.id;
+
+  try {
+    // Find the mentor by mentor ID
+    const mentor = await Mentor.findOne({
+      where: { id: mentorId },
+      include: { model: User, attributes: ["name", "profileImageUrl"] },
+    });
+
+    if (!mentor) {
+      return res.status(404).json({ error: "Mentor not found" });
+    }
+
+    // Return the mentor data in the response
+    res.json({ mentor });
+  } catch (error) {
+    console.error("Error fetching mentor profile:", error);
+    res.status(500).json({ error: "Server error" });
+  }
+});
+
 // Route to fetch mentor profiles
 router.get("/mentors", async (req, res) => {
   try {

--- a/Backend/Routes/users.js
+++ b/Backend/Routes/users.js
@@ -374,17 +374,25 @@ router.get("/mentees/menteeId/:id", async (req, res) => {
   const id = req.params.id;
 
   try {
-    // Find the mentor by user ID
-    const mentee = await Mentee.findOne({ where: { id } });
+    // Find the mentee by user ID and include the associated user data
+    const mentee = await Mentee.findOne({
+      where: { id },
+      include: [
+        {
+          model: User, // Assuming you have defined the association in your models
+          attributes: ["name", "profileImageUrl"], // Include only necessary attributes
+        },
+      ],
+    });
 
     if (!mentee) {
       return res.status(404).json({ error: "Mentee not found" });
     }
 
-    // Return the mentor data in the response
+    // Return the mentee data in the response
     res.json({ mentee });
   } catch (error) {
-    console.error("Error fetching mentor profile:", error);
+    console.error("Error fetching mentee profile:", error);
     res.status(500).json({ error: "Server error" });
   }
 });

--- a/Frontend/ApiService.js
+++ b/Frontend/ApiService.js
@@ -44,6 +44,22 @@ class ApiService {
       throw new Error(error.message);
     }
   }
+
+  // fetch a menotrs data
+  async fetchMentorDataMentorId(userId) {
+    try {
+      const response = await fetch(
+        `${config.apiBaseUrl}/mentors/mentorId/${userId}`
+      );
+      if (!response.ok) {
+        throw new Error("Failed to fetch mentor data");
+      }
+      const data = await response.json();
+      return data.mentor;
+    } catch (error) {
+      throw new Error(error.message);
+    }
+  }
 }
 
 export default ApiService;

--- a/Frontend/ApiService.js
+++ b/Frontend/ApiService.js
@@ -15,6 +15,22 @@ class ApiService {
     }
   }
 
+  // fetch a mentee's data using menteeId instead of user id
+  async fetchMenteeDataMenteeId(userId) {
+    try {
+      const response = await fetch(
+        `${config.apiBaseUrl}/mentees/menteeId/${userId}`
+      );
+      if (!response.ok) {
+        throw new Error("Failed to fetch mentee data");
+      }
+      const data = await response.json();
+      return data.mentee;
+    } catch (error) {
+      throw new Error(error.message);
+    }
+  }
+
   // fetch a menotrs data
   async fetchMentorData(userId) {
     try {

--- a/Frontend/src/App.jsx
+++ b/Frontend/src/App.jsx
@@ -124,6 +124,14 @@ function App() {
                   }
                 />
                 <Route
+                  path="/public-mentee-profile"
+                  element={
+                    <ProtectedRoute>
+                      <MenteeProfile />
+                    </ProtectedRoute>
+                  }
+                />
+                <Route
                   path="/notes"
                   element={
                     <ProtectedRoute>

--- a/Frontend/src/components/calendar/Calendar.css
+++ b/Frontend/src/components/calendar/Calendar.css
@@ -8,7 +8,7 @@
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
   border: 0.7px solid black;
   background-color: #7091e6;
-  width: 90%; /* Adjust width as needed */
+  width: 90%;
 }
 
 .fc-media-screen {

--- a/Frontend/src/components/home-page/HomePage.jsx
+++ b/Frontend/src/components/home-page/HomePage.jsx
@@ -4,7 +4,7 @@ import "./HomePage.css";
 function HomePage() {
   return (
     <div>
-      <h1>Welcom to the home page!</h1>
+      <h1>Welcome to the home page!</h1>
     </div>
   );
 }

--- a/Frontend/src/components/mentee/mentee-matches/MatchCard.jsx
+++ b/Frontend/src/components/mentee/mentee-matches/MatchCard.jsx
@@ -136,7 +136,6 @@ function MatchCard({
     setLoading(true);
     try {
       const mentor = await apiService.fetchMentorDataMentorId(mentorId);
-      // console.log(mentor);
       navigate("/public-mentor-profile", { state: { mentor } });
     } catch (error) {
       setErrorMessage("Failed to fetch mentee data.");

--- a/Frontend/src/components/mentee/mentee-matches/MatchCard.jsx
+++ b/Frontend/src/components/mentee/mentee-matches/MatchCard.jsx
@@ -1,7 +1,9 @@
 import { useState, useContext, useEffect } from "react";
 import { UserContext } from "../../../UserContext.jsx";
+import { useNavigate } from "react-router-dom";
 import config from "../../../../config.js";
 import "./MatchCard.css";
+import ApiService from "../../../../ApiService.js";
 import {
   Container,
   Box,
@@ -11,6 +13,14 @@ import {
   Alert,
   CircularProgress,
 } from "@mui/material";
+
+const experienceMappingReverse = {
+  1: "0-2",
+  2: "2-5",
+  3: "5-10",
+  4: "10+",
+  5: "20+",
+};
 
 const PLACEHOLDER =
   "https://ralfvanveen.com/wp-content/uploads/2021/06/Placeholder-_-Glossary.svg";
@@ -26,12 +36,15 @@ function MatchCard({
   reviews: initialReviews,
 }) {
   const { user } = useContext(UserContext);
+  const navigate = useNavigate();
   const [rating, setRating] = useState(5);
   const [textReview, setTextReview] = useState("");
   const [message, setMessage] = useState("");
   const [hasReviewed, setHasReviewed] = useState(false);
   const [loading, setLoading] = useState(false);
   const [reviews, setReviews] = useState(initialReviews);
+  const [errorMessage, setErrorMessage] = useState("");
+  const apiService = new ApiService();
 
   const handleRatingChange = (event) => {
     setRating(parseInt(event.target.value));
@@ -119,6 +132,19 @@ function MatchCard({
     }
   };
 
+  const handleViewProfile = async () => {
+    setLoading(true);
+    try {
+      const mentor = await apiService.fetchMentorDataMentorId(mentorId);
+      // console.log(mentor);
+      navigate("/public-mentor-profile", { state: { mentor } });
+    } catch (error) {
+      setErrorMessage("Failed to fetch mentee data.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
   useEffect(() => {
     checkReview();
   }, [reviews]);
@@ -130,7 +156,11 @@ function MatchCard({
           <CircularProgress />
         </div>
       ) : (
-        <div className="request-container">
+        <div
+          className="request-container"
+          id="mentor-request-container"
+          onClick={handleViewProfile}
+        >
           <div className="request-left">
             <div className="reqeust-img">
               <img src={mentorImage || PLACEHOLDER} alt="profile picture" />

--- a/Frontend/src/components/mentee/mentee-profile/MenteeProfile.jsx
+++ b/Frontend/src/components/mentee/mentee-profile/MenteeProfile.jsx
@@ -111,7 +111,6 @@ function MenteeProfile() {
             data.meetingPreferences?.preferredEndHour || "23:59",
         });
       } catch (error) {
-        console.error("Error fetching mentee data:", error);
         setUserData({
           name: "Failed to load user data",
           profileImageUrl: PLACEHOLDER,

--- a/Frontend/src/components/mentee/mentee-profile/MenteeProfile.jsx
+++ b/Frontend/src/components/mentee/mentee-profile/MenteeProfile.jsx
@@ -1,6 +1,6 @@
 import { useContext, useEffect, useState } from "react";
 import { UserContext } from "../../../UserContext.jsx";
-import { useNavigate, Link } from "react-router-dom";
+import { useNavigate, Link, useLocation } from "react-router-dom";
 import moment from "moment";
 import "./MenteeProfile.css";
 import MenteeProfileModal from "./MenteeProfileModal.jsx";
@@ -70,21 +70,26 @@ function MenteeProfile() {
   const [selectedSkills, setSelectedSkills] = useState([]);
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const navigate = useNavigate();
+  const location = useLocation(); // Added location
+  const [mentee, setMentee] = useState(location.state?.mentee || null);
   const { handleSignout } = useContext(UserContext);
   const [loading, setLoading] = useState(false);
   const apiService = new ApiService();
 
   const [userData, setUserData] = useState({
-    name: "Loading",
-    profileImageUrl: PLACEHOLDER,
-    bio: "",
-    major: "",
-    career_goals: "",
-    school: "",
-    skills: "",
-    preferredStartHour: "",
-    preferredEndHour: "",
+    name: mentee ? mentee.name : "Loading", // Updated to use mentee data if available
+    profileImageUrl: mentee
+      ? mentee.profileImageUrl || PLACEHOLDER
+      : PLACEHOLDER,
+    bio: mentee ? mentee.bio : "",
+    major: mentee ? mentee.major : "",
+    career_goals: mentee ? mentee.career_goals : "",
+    school: mentee ? mentee.school : "",
+    skills: mentee ? mentee.skills : "",
+    preferredStartHour: mentee
+      ? mentee.meetingPreferences.preferredStartHour
+      : "",
+    preferredEndHour: mentee ? mentee.meetingPreferences.preferredEndHour : "",
   });
 
   const fetchMenteeData = async () => {
@@ -118,8 +123,21 @@ function MenteeProfile() {
   };
 
   useEffect(() => {
-    fetchMenteeData();
-  }, [user]);
+    if (!mentee) {
+      fetchMenteeData();
+    } else {
+      setUserData({
+        name: userData.name,
+        school: userData.school,
+        major: userData.major,
+        bio: userData.bio,
+        career_goals: userData.career_goals,
+        skills: userData.skills,
+        meetingPreferences: userData.meetingPreferences,
+        profileImageUrl: userData.profileImageUrl || PLACEHOLDER,
+      });
+    }
+  }, [user, mentee]);
 
   const handleCheckboxChange = (skill) => {
     if (selectedSkills.includes(skill)) {
@@ -146,7 +164,7 @@ function MenteeProfile() {
         pages={["Dashboard", "Find Mentors"]}
         userName={user.name}
         profileImageUrl={user.profileImageUrl}
-        userRole="mentee"
+        userRole={user.userRole}
       />
       <Container>
         <Box sx={{ my: 2 }}>
@@ -160,30 +178,32 @@ function MenteeProfile() {
                 <div className="mp-top-left">
                   <h1>Mentee Profile</h1>
                 </div>
-                <div className="mp-top-right">
-                  <Button
-                    variant="contained"
-                    color="primary"
-                    onClick={handleSignout}
-                  >
-                    Log Out
-                  </Button>
-                  <Button
-                    variant="contained"
-                    color="primary"
-                    onClick={handleModalToggle}
-                  >
-                    Edit
-                  </Button>
-                  <Button
-                    variant="contained"
-                    color="primary"
-                    onClick={() => navigate("/notes")}
-                    sx={{ mr: 1 }}
-                  >
-                    Notes
-                  </Button>
-                </div>
+                {user.userRole === "mentee" && (
+                  <div className="mp-top-right">
+                    <Button
+                      variant="contained"
+                      color="primary"
+                      onClick={handleSignout}
+                    >
+                      Log Out
+                    </Button>
+                    <Button
+                      variant="contained"
+                      color="primary"
+                      onClick={handleModalToggle}
+                    >
+                      Edit
+                    </Button>
+                    <Button
+                      variant="contained"
+                      color="primary"
+                      onClick={() => navigate("/notes")}
+                      sx={{ mr: 1 }}
+                    >
+                      Notes
+                    </Button>
+                  </div>
+                )}
               </div>
               <div className="mp-body">
                 <div className="mp-left">

--- a/Frontend/src/components/mentee/mentee-profile/MenteeProfileModal.jsx
+++ b/Frontend/src/components/mentee/mentee-profile/MenteeProfileModal.jsx
@@ -97,7 +97,7 @@ function MenteeProfileModal({
         setSchoolSuggestions([]);
       }
     } catch (error) {
-      console.error("Error fetching school suggestions:", error);
+      setErrorMessage(error);
     }
   };
 

--- a/Frontend/src/components/mentor/mentor-matches/MentorMatchCard.css
+++ b/Frontend/src/components/mentor/mentor-matches/MentorMatchCard.css
@@ -1,0 +1,8 @@
+#mentor-request-container {
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+#mentor-request-container:hover {
+  transform: scale(1.05);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}

--- a/Frontend/src/components/mentor/mentor-matches/MentorMatchCard.jsx
+++ b/Frontend/src/components/mentor/mentor-matches/MentorMatchCard.jsx
@@ -24,8 +24,6 @@ function MentorMatchCard({
     setLoading(true);
     try {
       const menteeData = await apiService.fetchMenteeDataMenteeId(menteeId);
-      // console.log(menteeData);
-      // console.log(menteeData.User.name);
       const mentee = {
         name: menteeData.User.name,
         school: menteeData.school,
@@ -38,7 +36,6 @@ function MentorMatchCard({
         meetingPreferences: menteeData.meetingPreferences,
         profileImageUrl: menteeImage || PLACEHOLDER,
       };
-      console.log(mentee);
       navigate("/public-mentee-profile", { state: { mentee } });
     } catch (error) {
       setErrorMessage("Failed to fetch mentee data.");

--- a/Frontend/src/components/mentor/mentor-matches/MentorMatchCard.jsx
+++ b/Frontend/src/components/mentor/mentor-matches/MentorMatchCard.jsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
-import { UserContext } from "../../../UserContext.jsx";
-import config from "../../../../config.js";
+import { useNavigate } from "react-router-dom";
 import "../../mentee/mentee-matches/MatchCard.css";
+import "./MentorMatchCard.css";
+import ApiService from "../../../../ApiService.js";
 
 const PLACEHOLDER =
   "https://ralfvanveen.com/wp-content/uploads/2021/06/Placeholder-_-Glossary.svg";
@@ -12,22 +13,64 @@ function MentorMatchCard({
   menteeMajor,
   requestId,
   menteeImage,
+  menteeId,
 }) {
+  const navigate = useNavigate();
+  const apiService = new ApiService();
+  const [loading, setLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const handleViewProfile = async () => {
+    setLoading(true);
+    try {
+      const menteeData = await apiService.fetchMenteeDataMenteeId(menteeId);
+      // console.log(menteeData);
+      // console.log(menteeData.User.name);
+      const mentee = {
+        name: menteeData.User.name,
+        school: menteeData.school,
+        schoolState: menteeData.schoolState,
+        schoolCity: menteeData.schoolCity,
+        major: menteeData.major,
+        bio: menteeData.bio,
+        career_goals: menteeData.career_goals,
+        skills: menteeData.skills,
+        meetingPreferences: menteeData.meetingPreferences,
+        profileImageUrl: menteeImage || PLACEHOLDER,
+      };
+      console.log(mentee);
+      navigate("/public-mentee-profile", { state: { mentee } });
+    } catch (error) {
+      setErrorMessage("Failed to fetch mentee data.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
     <>
-      <div className="request-container">
-        <div className="request-left">
-          <div className="reqeust-img">
-            <img src={menteeImage || PLACEHOLDER} alt="profile picture" />
+      {loading ? (
+        <div className="loading-spinner">Loading...</div>
+      ) : (
+        <div
+          className="request-container"
+          id="mentor-request-container"
+          onClick={handleViewProfile}
+        >
+          <div className="request-left">
+            <div className="reqeust-img">
+              <img src={menteeImage || PLACEHOLDER} alt="profile picture" />
+            </div>
+            <div className="request-text">
+              <h3>{menteeName}</h3>
+              <p>{menteeSchool}</p>
+              <p>{menteeMajor}</p>
+            </div>
           </div>
-          <div className="request-text">
-            <h3>{menteeName}</h3>
-            <p>{menteeSchool}</p>
-            <p>{menteeMajor}</p>
-          </div>
+          <div className="request-right"></div>
         </div>
-        <div className="request-right"></div>
-      </div>
+      )}
+      {errorMessage && <div className="error-message">{errorMessage}</div>}
     </>
   );
 }

--- a/Frontend/src/components/mentor/mentor-matches/MentorMatches.jsx
+++ b/Frontend/src/components/mentor/mentor-matches/MentorMatches.jsx
@@ -80,6 +80,7 @@ function MentorMatches() {
               .map((request) => (
                 <MentorMatchCard
                   key={request.id}
+                  menteeId={request.menteeId}
                   menteeName={request.menteeName}
                   menteeImage={request.menteeImage}
                   menteeSchool={request.menteeSchool}

--- a/Frontend/src/components/mentor/mentor-profile/MentorProfile.jsx
+++ b/Frontend/src/components/mentor/mentor-profile/MentorProfile.jsx
@@ -192,7 +192,6 @@ function MentorProfile() {
 
       // fetch mentor reviews
       fetchMentorReveiews(mentor.id);
-      // filter so only reviews with
     }
   }, [user, mentor]);
 


### PR DESCRIPTION
This pull request introduces significant enhancements to the profile viewing functionality within the application:

- **Public Mentee Profile View**:
  - Implemented a new public-facing mentee profile that can be accessed by mentors.
  - Mentors can now click on a mentee card in their matches page to view the mentee's detailed profile, including bio, school, major, career goals, and skills.

- **Public Mentor Profile View**:
  - Enabled mentees to access a public-facing mentor profile through their matches page.
  - Mentees can now click on a mentor card in their matches page to view the mentor's detailed profile, including industry, company, work role, years of experience, and bio.

- **Console Cleanup**:
  - Removed unnecessary console logs to improve code readability and maintainability.

These updates aim to enhance the user experience by providing detailed and accessible profile views for both mentors and mentees directly from their respective match pages.

Video Demo:
In this demo, I access the public facing profile views through the matches page


https://github.com/user-attachments/assets/4890b1c7-deb7-412d-bf0e-0440786705d9

